### PR TITLE
Updated initMonitor

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -111,6 +111,6 @@ function initSwagger(app) {
 }
 
 function initMonitor(config) {
-  monitor.configure(config.app.monitor).start();
+  monitor.configure(config.monitor).start();
 }
 


### PR DESCRIPTION
Updated `initMonitor` to pass the correct `config` property.

Note: This PR relates directly to changes made in https://github.com/aquajs/aquajs-microservice/pull/40 and https://github.com/aquajs/aqua/pull/31. All of these should be merged/tested simultaneously.
