### PR TITLE
Apidoc context

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -67,10 +67,7 @@ function initSwagger(app) {
 
     var context = process.env.apidoc || 'apidoc';
 
-    //var regex = /^\\/{%context%\}(\\/.*)?$/;
-
-    console.log(typeof regex);
-    console.log(typeof /^\/apidoc(\/.*)?$/);
+    var regex = new RegExp('^\\/' + context + '(\\/.*)?$');
 
     app.get(regex, function (req, res, next) {
       if (setSwaggerContext) {
@@ -94,6 +91,10 @@ function initSwagger(app) {
         res.end();
         return;
       }
+
+      // take off leading /docs so that connect locates file correctly
+      req.url = req.url.substr(('/' + context).length);
+      return docs_handler(req, res, next);
 
     });
 


### PR DESCRIPTION
https://github.com/aquajs/project/issues/149

This PR is for adding a `context` variable that can be assigned by the environment before defaulting to `'apidoc'`. 
